### PR TITLE
Flanking

### DIFF
--- a/rules/combat.md
+++ b/rules/combat.md
@@ -1,0 +1,6 @@
+# Combat
+
+## Flanking
+Flanking would be a pseudo-condition that grants +2 bonus to melee attacks against the flanked target. Two allies are said to be flanking a creature if the allies are not incapacitated, on opposite sides of the creature, and adjacent to the creature. 
+
+Certain creatures (those with blindsight, tremorsense, or multiple heads) would be immune to flanking.


### PR DESCRIPTION
Flanking was a fun tactic in 4th edition (and possibly earlier editions) wherein two allies would stand on opposing sides of a creature to get "combat advantage." (Combat advantage was similar to 5e's advantage in that you could only benefit from a single source of it, but it just gave a flat +2 bonus to an attack role.) It seeks to address #1.

## Positioning
A +2 bonus is a big incentive to engage in flanking. Since every melee attacker wants to flank, but no one wants to be flanked, flanking should encourage constant repositioning to break or reform flanks.

As a side effect, it encourages melee attackers to focus on a particular enemy. This is generally a common PC tactic anyways, but monsters might become more mean when they gain such an obvious benefit from focusing a PC. To alleviate this, perhaps creatures with low Int cannot contribute to a flank. "Stupid" creatures (beasts in particular) have Pack Tactics when it is clear that they should engage in flanking tactics anyways.

## Bounded Accuracy
This core tenet of 5e has deteriorated somewhat. Forge clerics can easily give +1 AC to anyone, and artificers can give +5 (+2 shield, +2 armor, and cloak of protection) by level 10 or so. Various subclasses have ways of increasing AC as well (e.g. bladesong, sword bard's defensive flourish), plus some new spells (_otherworldly guise_). Feat points also make _shield_ more accessible.

Power creep has not touched attack rolls, however. Worse, the real problem is that chaff monsters cannot hit high-AC players, and obviously chaff monsters will not get any power creep. Simply increasing monster attack rolls is not a solution either.

This is the real benefit of flanking: it helps monsters hit powercrept AC, but is fun for everyone.

And for comparison, the archery fighting style gives an unconditional +2 bonus to ranged attack rolls. It did not break bounded accuracy. Since flanking is a) situational and b) cannot stack with archery, it should not be too much for PCs to have access to.