### PR TITLE
Charge as an action

### DIFF
--- a/src/rules/combat.md
+++ b/src/rules/combat.md
@@ -10,7 +10,7 @@ A creature with blindsight, tremorsense, or multiple heads cannot be flanked.
 
 ### Charge
 
-When you take the Charge action, you gain the effects of the Dash action. If you end your movement closer to a creature than where you started, you can make a melee weapon attack against that creature if it is within your reach. If you make this attack, your turn ends immediately afterwards, and the next attack roll made against you before the start of your next turn has advantage.
+When you take the Charge action, you gain the effects of the Dash action. If you end your movement closer to a creature than where you started, you can make a melee weapon attack against that creature if it is within your reach. If you make this attack, the next attack roll made against you before the start of your next turn has advantage.
 
 > #### The Charger Feat
 > 

--- a/src/rules/combat.md
+++ b/src/rules/combat.md
@@ -6,6 +6,16 @@ Flanking is be a pseudo-condition that grants +2 bonus to melee attacks against 
 
 A creature with blindsight, tremorsense, or multiple heads cannot be flanked.
 
+## Actions in Combat
+
+### Charge
+
+When you take the Charge action, you gain the effects of the Dash action. If you end your movement closer to a creature than where you started, you can make a melee weapon attack against that creature if it is within your reach. If you make this attack, your turn ends immediately afterwards, and the next attack roll made against you before the start of your next turn has advantage.
+
+> #### The Charger Feat
+> 
+> This action is intended to replace the Charger feat. The feat could be revised to enhance the Charge action in some way.
+
 # DM Advice
 
 ## Recharging Monster Abilities

--- a/src/rules/combat.md
+++ b/src/rules/combat.md
@@ -2,9 +2,9 @@
 
 ## Flanking
 
-Flanking would be a pseudo-condition that grants +2 bonus to melee attacks against the flanked target. Two allies are said to be flanking a creature if the allies are not incapacitated, on opposite sides of the creature, and adjacent to the creature.
+Flanking is be a pseudo-condition that grants +2 bonus to melee attacks against the flanked target. Two allies are said to be flanking a creature if the allies are not incapacitated, on opposite sides of the creature, and adjacent to the creature. 
 
-Certain creatures (those with blindsight, tremorsense, or multiple heads) would be immune to flanking.
+A creature with blindsight, tremorsense, or multiple heads cannot be flanked.
 
 # DM Advice
 


### PR DESCRIPTION
# Charging

This outlines a simple rule to make charging an accessible tactic to all characters.

Charging solves the awkward scenario where a melee character can't reach a foe without dashing. Currently, there are 3 options for most players in this scenario:

1. Dash to get all the way, and end adjacent to the enemy
2. Move halfway up and dodge
3. Move halfway up and ready an attack

None of these are nearly as satisfying as the solution presented by the Charger feat, which allows one to both Dash and make a single (boosted) attack as a bonus action.

Giving the Charger feat to everyone is not a solution. It is too strong, especially before Extra Attack features. Worse, in its current state, it can be used every turn by backing up and charging again. The opportunity attack this incurs is not enough of a drawback, especially for high AC and/or Riposte builds. Furthermore, the action/bonus action combo stands out as awkward.

This new Charge action slightly enhances melee fighting (related to #1) and excises the Charger feat. Its thinking is as follows:
- The requirement of being closer prevents back-up jank (which there is currently no incentive to do, but a revisited Charger feat might provide one)
- No linear motion is required, since such a requirement is a) verbose, b) inferior to the "closer" requirement in terms of mechanical goal (to stop back-up jank), and c) usually trivial to satisfy anyways
- The turn ends after the attack to prevent bonus action attacks after the charge, but leaves a beforehand bonus action available (to activate Rage, for example)
- The advantage-to-be-hit afterwards reflects the reckless nature of a charge (and could be removed by a feat, fighting style, or other feature), and makes the decision of whether or not to charge less trivial (unless you are a barbarian using Reckless Attack, which is fitting)