### PR TITLE
Attack casting time for spells

### DIFF
--- a/src/rules/spellcasting.md
+++ b/src/rules/spellcasting.md
@@ -1,0 +1,9 @@
+# Spellcasting
+
+## Casting Multiple Spells in One Turn
+
+When you cast multiple spells in one turn, only one spell may be of 1st-level or higher.
+
+## Attack Casting Time
+
+Spells with a casting time of "Attack" may be cast in place of an attack when you take the Attack action.


### PR DESCRIPTION
These rules add a new option for spell casting time: Attack. This allows a spell to be substituted for one attack when you take the attack action. My goal with this is to allow some spells, such as the smite spells and their ranger brethren to have a casting time of 1 attack, and to allow more design space for future spells.